### PR TITLE
build(dependencies): fix a couple of issues in the build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,8 +81,12 @@ jobs:
               exit 1
             else
               echo "Build will not fail as it is triggered automatically"
+              echo "FOLDERS=" >> $GITHUB_ENV
+              exit 0
             fi
           fi
+          # Obtain images modified indirectly
+          folders=$(make build-candidates SUBDIRS=${folders} | tail -n 1)
           echo "FOLDERS=${folders}" >> $GITHUB_ENV
 
   build:
@@ -129,11 +133,12 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}
           echo "Building ${SUBDIRS}"
+          # for building PRs PUBLISH_URL points to the public server, so we can download unchanged images
           make build \
             SUBDIRS="${SUBDIRS}" \
-            PUBLISH_URL=docker://localhost:5000/c3 \
-            PUBLISH_EXTRA_ARGS="--skip-tls" \
-            PULL_EXTRA_ARGS="--src-tls-verify=false"
+            PUBLISH_URL=docker://zothub.io/c3
+          # for publishing PRs PUBLISH_URL points to the local server so we can later run the CVE scanner
+          # without having to push images to the public server
           make publish \
             SUBDIRS="${SUBDIRS}" \
             PUBLISH_URL=docker://localhost:5000/c3 \

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ build-order:
 	rm -f $(BUILD_ORDER_FILE); \
 	$(DEPS_SCRIPT) --deps-file $(DEPS_FILE) --images $(subst $(space),$(comma),$(SUBDIRS)) --build-order --out-file $(BUILD_ORDER_FILE)
 
+.PHONY: build-candidates
+build-candidates: build-order
+	jq -c -j '.[][] + " "' $(BUILD_ORDER_FILE) | xargs echo -n
+
 .PHONY: identify-skippable-images
 identify-skippable-images:
 	mkdir -p $(BUILD_DIR); \


### PR DESCRIPTION
1. build(dependencies): fix workflows not scanning/signing indirectly modified images

Since some images are indirectly modified, by changed bases, the workflow scripts were not aware of them, so the logic outside the makefiles only ran for directly modified images.

The job responsible for determining changed folders will now provide the full list.

2. build(dependencies): fix unchanged images not being available for download in case of partially building PRs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
