### PR TITLE
ci(timeout): increase timeout since one of the builds timed out

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,7 +96,7 @@ jobs:
       (github.ref != 'refs/heads/main') &&
       (needs.generate_build_input.outputs.folders_to_build != '')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       max-parallel: 3
       matrix:
@@ -172,7 +172,7 @@ jobs:
       (github.ref == 'refs/heads/main') &&
       (needs.generate_build_input.outputs.folders_to_build != '')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       DOCKER_CONFIG: $HOME/.docker
     strategy:


### PR DESCRIPTION
See:
https://github.com/project-stacker/c3/actions/runs/5135857700/jobs/9241833213

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
